### PR TITLE
Fix wc command: output of old version would not have parsed as int.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ task cgrep {
 
 task wc {
   command {
-    wc -l ${File in_file}
+    cat ${File in_file} | wc -l
   }
   output {
     Int count = read_int("stdout")


### PR DESCRIPTION
e.g.:
```
wmd3c-7fd:cromwell mcovarr$ wc -l README.md 
      59 README.md
```