### PR TITLE
removed non-collaborators from .pullapprove.yml

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -11,6 +11,3 @@ reviewers:
         - mcovarr
         - geoffjentry
         - kshakir
-        - francares
-        - gauravs90
-        - jainh


### PR DESCRIPTION
These guys are apparently not collaborators on this repo