### PR TITLE
PublicPairedSingleSampleWf: create reference cache from fasta.

### DIFF
--- a/scripts/broad_pipelines/PublicPairedSingleSampleWf_160720.wdl
+++ b/scripts/broad_pipelines/PublicPairedSingleSampleWf_160720.wdl
@@ -496,7 +496,9 @@ task ConvertToCram {
       samtools view -C -T ${ref_fasta} ${input_bam} | \
       tee ${output_basename}.cram | \
       md5sum > ${output_basename}.cram.md5 && \
-      samtools index ${output_basename}.cram && \
+      seq_cache_populate.pl -root ./ref/cache ${ref_fasta} && \
+      REF_PATH=: REF_CACHE=./ref/cache/%2s/%2s/%s \
+        samtools index ${output_basename}.cram &&
       mv ${output_basename}.cram.crai ${output_basename}.crai
   >>>
   runtime {


### PR DESCRIPTION
Avoids fetching from EBI servers during "samtools index <cram>"
by creating the local reference cache from the input fasta.
The fetch from EBI can hang "samtools index" as described here:
  https://github.com/samtools/htslib/issues/412
The approach added here is that recommended by:
  http://www.htslib.org/workflow/#the-refpath-and-refcache
except without the fallback to EBI.