### PR TITLE
New directory for supported-but-not-prod WDLs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,18 +1,17 @@
-This directory contains WDL scripts organized in the following
-categories:
+This directory contains WDL scripts organized in the following alphabetically listed categories:
+
+####`broad_dsde_workflows/`
+Workflow scripts developed by the Data Sciences and Data Engineering (DSDE) group at the Broad Institute. These scripts cover a variety of use cases, typically complementary to the production workflows provided in `broad_pipelines`, e.g. for formatting inputs correctly for the production pipelines, or serving as alternatives for use with divergent datatypes or with legacy tools and resources. Although they are not blessed by the Broad production team, these workflows are officially supported on the WDL user forum. See the directory README for additional guidelines.
+
+####`broad_pipelines/`
+Workflow scripts used in Broad Genomic Services production pipelines at the Broad Institute. These are intended to serve as reference implementations of the GATK Best Practices workflows and may require specific resources for execution. See the directory README for more information on each script. 
 
 ####`tutorials/`
-Scripts used in
+Workflow scripts used in
 [tutorials](https://software.broadinstitute.org/wdl/userguide/topic?
 name=wdl-tutorials) in the WDL user guide. These scripts demonstrate
 various features of WDL using GATK analyses as backdrop. A link to the
 corresponding tutorial is included in the header of each script.
-
-####`broad_pipelines/`
-Pipeline scripts used in production at the Broad Institute. These are
-intended to serve as reference implementation of the GATK Best Practices
-workflows and may require specific resources for execution. See the
-directory README for more information on each script. 
 
 ####`wrappers/gatk/`
 GATK tools have been wrapped into individual WDL tasks using a json-

--- a/scripts/broad_dsde_workflows/README.md
+++ b/scripts/broad_dsde_workflows/README.md
@@ -1,0 +1,6 @@
+This directory contains WDL scripts developed at the Broad Institute and supported by the DSDE group (which develops GATK, Picard and Cromwell/WDL among other things). These scripts are NOT run in production at Broad; for production pipeline scripts, see the `broad_pipelines` directory. 
+
+When these scripts get updated, old versions are stored in the `archive` directory. Versions are distinguished with a datestamp (format: YYMMDD). Each WDL  script is accompanied by a JSON file of example inputs bearing the same  name, with the `.inputs.json` extension instead of `.wdl`. Unless otherwise specified, all WDL scripts can be run with the generic options file `generic.options.json`. 
+
+
+

--- a/scripts/broad_dsde_workflows/generic.options.json
+++ b/scripts/broad_dsde_workflows/generic.options.json
@@ -1,0 +1,6 @@
+{
+	"read_from_cache":false,
+	"defaultRuntimeOptions": {
+		"zones": "us-central1-a us-central1-b us-central1-c"
+	}
+}


### PR DESCRIPTION
This PR includes a README stating the purpose of this new directory and a generic options file so we don't have to provide a separate one for each WDL.

No archive directory yet since git doesn't do empty dirs (?) but plan to make one on first update. 