### PR TITLE
Removed output typing from workflows

### DIFF
--- a/scripts/broad_dsde_workflows/ConvertPairedFastQToUnmappedBamWf_170107.wdl
+++ b/scripts/broad_dsde_workflows/ConvertPairedFastQToUnmappedBamWf_170107.wdl
@@ -91,7 +91,7 @@ workflow ConvertPairedFastQsToUnmappedBamWf {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[File] output_bams = PairedFastQsToUnmappedBAM.output_bam
+    PairedFastQsToUnmappedBAM.output_bam
   }
 }
 

--- a/scripts/broad_dsde_workflows/ExtractSamHeadersWf_170107.wdl
+++ b/scripts/broad_dsde_workflows/ExtractSamHeadersWf_170107.wdl
@@ -78,7 +78,7 @@ workflow ExtractSamHeadersWf {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[File] output_headers = ExtractSAMHeader.output_header
+    ExtractSAMHeader.output_header
   }
 }
 

--- a/scripts/broad_dsde_workflows/RevertBamToUnmappedRGBamsWf_170107.wdl
+++ b/scripts/broad_dsde_workflows/RevertBamToUnmappedRGBamsWf_170107.wdl
@@ -72,6 +72,6 @@ workflow RevertBamToUnmappedRGBamsWf {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[File] unmapped_bams_output=RevertBamToUnmappedRGBams.unmapped_bams
+    RevertBamToUnmappedRGBams.unmapped_bams
   }
 }

--- a/scripts/broad_dsde_workflows/RevertRGBamsToPairedFastQsWf_170107.wdl
+++ b/scripts/broad_dsde_workflows/RevertRGBamsToPairedFastQsWf_170107.wdl
@@ -75,7 +75,7 @@ workflow RevertRGBamsToPairedFastQsWf {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[Array[File]] output_fastqs_globs=RevertBAMToPairedFASTQ.output_fastqs
+    RevertBAMToPairedFASTQ.output_fastqs
   }
 }
 

--- a/scripts/broad_dsde_workflows/ValidateBamsWf_170107.wdl
+++ b/scripts/broad_dsde_workflows/ValidateBamsWf_170107.wdl
@@ -74,7 +74,7 @@ workflow ValidateBamsWf {
 
   # Outputs that will be retained when execution is complete
   output {
-    Array[File] validation_reports = ValidateBAM.validation_report
+    ValidateBAM.validation_report
   }
 }
 


### PR DESCRIPTION
While getting my feet wet with WDL I got hit by the error below in a DSDE example script. Changes in this pull fix the issue I encounter.

```
Unable to load namespace from workflow: Unrecognized token on line 94, column 10:

    Array[File] output_bams = PairedFastQsToUnmappedBAM.output_bam
         ^
cromwell.engine.workflow.MaterializeWorkflowDescriptorActor$$anonfun$receive$1$$anon$1: Workflow input processing failed.
Unable to load namespace from workflow: Unrecognized token on line 94, column 10:

    Array[File] output_bams = PairedFastQsToUnmappedBAM.output_bam
         ^
	at cromwell.engine.workflow.MaterializeWorkflowDescriptorActor$$anonfun$receive$1.applyOrElse(MaterializeWorkflowDescriptorActor.scala:69) ~[cromwell.jar:0.19]
	at akka.actor.Actor$class.aroundReceive(Actor.scala:467) ~[cromwell.jar:0.19]
	at cromwell.engine.workflow.MaterializeWorkflowDescriptorActor.aroundReceive(MaterializeWorkflowDescriptorActor.scala:59) ~[cromwell.jar:0.19]
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:516) [cromwell.jar:0.19]
	at akka.actor.ActorCell.invoke(ActorCell.scala:487) [cromwell.jar:0.19]
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:238) [cromwell.jar:0.19]
	at akka.dispatch.Mailbox.run(Mailbox.scala:220) [cromwell.jar:0.19]
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397) [cromwell.jar:0.19]
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [cromwell.jar:0.19]
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [cromwell.jar:0.19]
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [cromwell.jar:0.19]
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [cromwell.jar:0.19]
```

