### PR TITLE
fixing typo in cross example

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2582,7 +2582,7 @@ Array[Int] xs = [ 1, 2, 3 ]
 Array[String] ys = [ "a", "b", "c" ]
 Array[String] zs = [ "d", "e" ]
 
-Array[Pair[Int, String]] crossed = crossProduct(xs, zs) # i.e. crossed = [ (1, "d"), (1, "e"), (2, "d"), (2, "e"), (3, "d"), (3, "e") ]
+Array[Pair[Int, String]] crossed = cross(xs, zs) # i.e. crossed = [ (1, "d"), (1, "e"), (2, "d"), (2, "e"), (3, "d"), (3, "e") ]
 ```
 
 ## Integer length(Array[X])


### PR DESCRIPTION
replacing incorrect use of crossProduct with cross